### PR TITLE
Inline php info (instead of using iframe)

### DIFF
--- a/PowerTools/PowerToolsController.php
+++ b/PowerTools/PowerToolsController.php
@@ -23,6 +23,8 @@ class PowerToolsController extends Controller
         phpInfo();
         $html = ob_get_contents();
         ob_end_clean();
+         
+        $html = preg_replace( '%^.*<body>(.*)</body>.*$%ms','$1',$html);
 
         return $html;
     }

--- a/PowerTools/resources/views/phpinfo.blade.php
+++ b/PowerTools/resources/views/phpinfo.blade.php
@@ -1,5 +1,33 @@
 @extends('layout')
 
+<style>
+	.center > table {
+		background-color: #fff;
+		border-radius: 3px;
+		box-shadow: 0 1px 3px rgba(0,0,0,.25);
+	}
+	.center > table td,
+	.center > table th {
+		padding: 15px;
+	}
+	.center > table th {
+		font-size: 20px;
+	}
+	.h a,
+	.v a {
+		display: inline-block;
+		float: left;
+		margin-right: 30px;
+	}
+	.e {
+		vertical-align: top;
+	}
+	.v {
+		max-width: 300px;
+		word-wrap: break-word;
+	}
+</style>
+
 @section('content')
-<iframe src="data:text/html,{{ $html }}" style="width: 100%; height: calc(100vh - 150px); border: 0;"></iframe>
+	{!! $html !!}
 @stop


### PR DESCRIPTION
Put PHP info inline for more constant style and fix iFrame not visible in Firefox.

Fixes #5 