### PR TITLE
use named routes to generate addon urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.idea
+Thumbs.db

--- a/PowerTools/PowerToolsWidget.php
+++ b/PowerTools/PowerToolsWidget.php
@@ -17,8 +17,7 @@ class PowerToolsWidget extends Widget
         // Get settings
         $settings    = $this->getConfig();
         $github_page = $this->getMeta()['url'];
-        $cp_path     = CP_ROUTE;
 
-        return $this->view('widget', compact('settings', 'github_page', 'cp_path'))->render();
+        return $this->view('widget', compact('settings', 'github_page'))->render();
     }
 }

--- a/PowerTools/resources/views/widget.blade.php
+++ b/PowerTools/resources/views/widget.blade.php
@@ -6,8 +6,8 @@
                 <i class="icon icon-dots-three-vertical"></i>
             </button>
             <ul class="dropdown-menu">
-                <li><a href="/{{ $cp_path }}/settings/cp"><span class="icon icon-browser" aria-hidden="true"></span> Widget Settings</a></li>
-                <li><a href="/{{ $cp_path }}/addons/power-tools/settings"><span class="icon icon-power-plug" aria-hidden="true"></span> Addon Settings</a></li>
+                <li><a href="{{ route('settings.edit', 'cp') }}"><span class="icon icon-browser" aria-hidden="true"></span> Widget Settings</a></li>
+                <li><a href="{{ route('addon.settings', 'PowerTools') }}"><span class="icon icon-power-plug" aria-hidden="true"></span> Addon Settings</a></li>
                 <li><a href="{{ $github_page }}" target="_blank"><span class="icon icon-github" aria-hidden="true"></span> Github Page</a></li>
             </ul>
         </div>
@@ -15,7 +15,7 @@
 
     <div class="card-body padding-bottom">
         <div>
-            <a href="/{{ $cp_path }}/addons/powertools/rebuild-search" class="btn">Rebuild Index</a>
+            <a href="{{ route('powertools.rebuild-search') }}" class="btn">Rebuild Index</a>
         </div>
     </div>
 
@@ -25,26 +25,26 @@
 
     <div class="card-body padding-bottom">
         <div class="btn-group">
-            <a href="/{{ $cp_path }}/addons/powertools/update-stache" class="btn">Update Stache</a>
+            <a href="{{ route('powertools.update-stache') }}" class="btn">Update Stache</a>
         </div>
         <div class="btn-group">
-            <a href="/{{ $cp_path }}/addons/powertools/clear-cache" class="btn">Clear Cache</a>
+            <a href="{{ route('powertools.clear-cache') }}" class="btn">Clear Cache</a>
         </div>
         <div class="btn-group">
-            <a href="/{{ $cp_path }}/addons/powertools/clear-static" class="btn">Clear Static Cache</a>
+            <a href="{{ route('powertools.clear-static') }}" class="btn">Clear Static Cache</a>
         </div>
     </div>
-    
+
     <div class="card-header padding-top">
         <h2>Glide Assets</h2>
     </div>
-    
+
     <div class="card-body padding-bottom">
         <div class="btn-group">
-            <a href="/{{ $cp_path }}/addons/powertools/assets-generate-presets" class="btn">Generate Presets</a>
+            <a href="{{ route('powertools.assets-generate-presets') }}" class="btn">Generate Presets</a>
         </div>
         <div class="btn-group">
-            <a href="/{{ $cp_path }}/addons/powertools/assets-regenerate-presets" class="btn">Regenerate Presets</a>
+            <a href="{{ route('powertools.assets-regenerate-presets') }}" class="btn">Regenerate Presets</a>
         </div>
     </div>
 </div>

--- a/PowerTools/routes.yaml
+++ b/PowerTools/routes.yaml
@@ -4,11 +4,23 @@ routes:
     uses: phpinfo
     as: phpinfo
 
-  /rebuild-search: rebuildSearchIndex
+  /rebuild-search:
+    uses: rebuildSearchIndex
+    as: powertools.rebuild-search
 
-  /clear-cache: clearCache
-  /clear-static: clearStaticCache
-  /update-stache: updateStache
+  /clear-cache:
+    uses: clearCache
+    as: powertools.clear-cache
+  /clear-static:
+    uses: clearStaticCache
+    as: powertools.clear-static
+  /update-stache:
+    uses: updateStache
+    as: powertools.update-stache
 
-  /assets-generate-presets: generatePresets
-  /assets-regenerate-presets: regeneratePresets
+  /assets-generate-presets:
+    uses: generatePresets
+    as: powertools.assets-generate-presets
+  /assets-regenerate-presets:
+    uses: regeneratePresets
+    as: powertools.assets-regenerate-presets


### PR DESCRIPTION
This fixes the url changes with statamic version 2.6.0 in a backwards compatible way.

All the urls are now generated with the `route` helper